### PR TITLE
Fixed Json.Deserialize in Facebook request token by removing extra '{'

### DIFF
--- a/Oauth2Login/Service/FacebookService.cs
+++ b/Oauth2Login/Service/FacebookService.cs
@@ -44,9 +44,12 @@ namespace Oauth2Login.Service
                 "code", code
             );
 
-            string resonseJson = HttpPost(tokenUrl, postData);
-            resonseJson = "{\"" + resonseJson.Replace("=", "\":\"").Replace("&", "\",\"") + "\"}";
-            return JsonConvert.DeserializeAnonymousType(resonseJson, new { access_token = "" }).access_token;
+            string responseJson = HttpPost(tokenUrl, postData);
+            responseJson = responseJson.Replace("=", "\":\"").Replace("&", "\",\"");
+
+            if (responseJson.Substring(0, 1) != "{")
+                responseJson = "{\"" + responseJson + "\"}";
+            return JsonConvert.DeserializeAnonymousType(responseJson, new { access_token = "" }).access_token;
         }
 
         public override void RequestUserProfile()

--- a/Oauth2Login/Service/FacebookService.cs
+++ b/Oauth2Login/Service/FacebookService.cs
@@ -76,7 +76,7 @@ namespace Oauth2Login.Service
         public string gender { get; set; }
         public string picture { get; set; }
         public string locale { get; set; }
-        public int timezone { get; set; }
+        public double timezone { get; set; }
         public bool verified { get; set; }
 
         // override


### PR DESCRIPTION
Hi Le, 

I've fixed a problem in Facebook service RequestToken. I got a problem with Deserializing Json response, it has an extra "{" curly braces. When i removed the extra "{" curly braces, i can now proceed to facebook login.
Here is the error message i got:
Invalid character after parsing property name. Expected ':' but got: a. Path '', line 1, position 4.

Here is the old responseJson string:
{"{"access_token":"1erwEdfffffQESXqY3by1CGym1GZAEf1W5nrZA3LdIvh04GR2V62EJRnQp68L53Wer6Nhy44szv7V5Y3hJBTSAOig8nkN1mJvplnejTEdhdsfsafasdfgeRdgoBZCUtgq32adfasfZD","token_type":"bearer","expires_in":5156483}"}

here is the new fixed:
{"access_token":"1erwEdfffffQESXqY3by1CGym1GZAEf1W5nrZA3LdIvh04GR2V62EJRnQp68L53Wer6Nhy44szv7V5Y3hJBTSAOig8nkN1mJvplnejTEdhdsfsafasdfgeRdgoBZCUtgq32adfasfZD","token_type":"bearer","expires_in":5156483}

I think the problem comes from Json.Net version where it cannot parse correctly when given an extra curly braces in json string.